### PR TITLE
Adjusted the rating for Szomor, because it was out of line with other…

### DIFF
--- a/data.json
+++ b/data.json
@@ -82,7 +82,7 @@
 						"md":"data/SzomorBajna.md",
 						"kml":"data/SzomorBajna.kml",
 						"upd":"2021 március",
-						"rat": 2
+						"rat": 4
 					},
 					{
 						"ttl":"Gerecsei Bejáróút: Tát - Tatabánya",


### PR DESCRIPTION
… routes

Note for reviewer: https://kmlviewer.nsspot.net/ can be used to open KML files online.
