### PR TITLE
Fixed an issue with initial route focusing

### DIFF
--- a/res/huroutes.js
+++ b/res/huroutes.js
@@ -227,10 +227,7 @@ function addRoute(data)
         }
 
         if (window.location.hash == '#' + routeId)
-        {
-            event.layer.routeId = routeId;
-            activateRoute(event.layer);
-        }
+            activateRoute(layer); // event.layer is a different instance; must use layer from closure
     });
     layer.routeId = routeId;
     omnivore.kml(data.kml, null, layer).addTo(map);


### PR DESCRIPTION
Previously, when loading huroutes using a #-route link, the focused route would be unfocused once the mouse is hovered over it

Note for reviewer: https://kmlviewer.nsspot.net/ can be used to open KML files online.
