### PR TITLE
Added a console warning to the frontend, when a required `upd` field is missing

### DIFF
--- a/res/huroutes.js
+++ b/res/huroutes.js
@@ -224,8 +224,13 @@ function createMenuRouteItem(elem, data)
 
 function createInfoPanel(elem, data)
 {
-    if (!data.rat && !data.bkg)
-        console.warn('No rating given for ' + data.ttl);
+    if (!data.bkg)
+    {
+        if (!data.rat)
+            console.warn('No rating given for ' + data.ttl);
+        if (!data.upd)
+            console.warn('No last update date given for ' + data.ttl);
+    }
     if (data.rat || data.upd)
     {
         var elemHeader = $('<p class="route-header"/>');


### PR DESCRIPTION
Note for reviewer: https://kmlviewer.nsspot.net/ can be used to open KML files online.
