### PR TITLE
Updated the dates for Vértes routes

### DIFF
--- a/data.json
+++ b/data.json
@@ -134,21 +134,21 @@
 						"md":"data/EtyekAlcsutdoboz.md",
 						"kml":"data/EtyekAlcsutdoboz.kml",
 						"rat":5,
-						"upd":"2022 március"
+						"upd":"2022 július"
 					},
 					{
 						"ttl":"Söréd - Gánt",
 						"md":"data/SoredGant.md",
 						"kml":"data/SoredGant.kml",
 						"rat":5,
-						"upd":"2022 március"
+						"upd":"2022 július"
 					},
 					{
 						"ttl":"Gánt - Csákvár",
 						"md":"data/GantCsakvar.md",
 						"kml":"data/GantCsakvar.kml",
 						"rat":5,
-						"upd":"2022 június"
+						"upd":"2022 július"
 					},
 					{
 						"ttl":"Vértesi Bejáróút",


### PR DESCRIPTION
Note for reviewer: https://kmlviewer.nsspot.net/ can be used to open KML files online.
