### PR TITLE
Removed the old cookie setting migration code.

### DIFF
--- a/res/huroutes.js
+++ b/res/huroutes.js
@@ -95,8 +95,6 @@ String.prototype.format = function () {
 
 (function() {
 
-migrateCookieSettings();
-
 var langDict = selectLanguage();
 var markdown = new showdown.Converter();
 var map;
@@ -553,21 +551,6 @@ function initAdToast()
         androidToast.on('hide.bs.toast', () => localStorage.shownAndroidAd = true)
         androidToast.find('a[href]').on('click', () => androidToast.toast('hide'))
     }
-}
-
-// TODO: Remove this
-function migrateCookieSettings()
-{
-    document.cookie.split(";").forEach(c => {
-        const opts = ['dltype', 'mapstyle', 'navprovider', 'overlays'];
-        var [key, value] = c.trim().split('=');
-        const opt = key.replace('huroutes-', '');
-        if (opts.includes(opt))
-        {
-            localStorage.setItem(opt, decodeURIComponent(value));
-            document.cookie = 'huroutes-{0}=;expires={1};path=/'.format(opt, new Date().toUTCString());
-        }
-    });
 }
 
 })();


### PR DESCRIPTION
Note for reviewer: https://kmlviewer.nsspot.net/ can be used to open KML files online.
