### PR TITLE
Fixed insufficient sidebar opening void length

### DIFF
--- a/res/huroutes.css
+++ b/res/huroutes.css
@@ -98,7 +98,8 @@ a:hover {
   display: block;
 }
 #void-open-sidebar {
-  left: 0; right: -12px; top: 0; bottom: 0;
+  left: 0; top: 0;
+  width: 100%; height: 9999%; /* % is without parent's overflow :( */
   position: absolute;
   z-index: 1033;
 }


### PR DESCRIPTION
Repro:
* Set portrait view (narrow window)
1. Open a long description in the left panel
2. Scroll down to the bottom
3. Activate the right panel
4. Observe that the darkened overlay does not cover the bottom of the left panel.