### PR TITLE
Added direct linking with history to the linkmaker

### DIFF
--- a/linkmaker.html
+++ b/linkmaker.html
@@ -10,6 +10,7 @@
   <link rel="icon" href="res/favicon-sm.png" sizes="16x16" type="image/png" />
 
   <script>
+    webRoot = 'https://sp3eder.github.io/huroutes/';
     function parseGeo(str) {
       const round6 = n => Number(Number(n).toFixed(6))
       const geoParse = /\s*(-?[0-9\.]+)\s*,\s*(-?[0-9\.]+)\s*/;
@@ -33,14 +34,20 @@
       var result = `#geo:${encode(data.title)}@${data.geo[0]},${data.geo[1]}`;
       if (data.desc)
         result += `/?b=${encode(data.desc)}`
-      document.getElementById('link').value = result;
-      document.getElementById('link').focus();
+      with (document.getElementById('linkEdit'))
+      {
+        value = result;
+        focus();
+      }
+      with (document.getElementById('link'))
+        innerText = href = webRoot + result;
       document.execCommand('copy');
+      window.history.pushState(null, '', result);
       return false;
     }
-    function parseLink() {
+    function parseLink(link = document.getElementById('linkEdit').value) {
       const re = /#geo:([^@]+)@(-?[0-9\\.]+),(-?[0-9\\.]+)(?:\/(?:[?&](?:b=([^&]+)))*)?/;
-      m = re.exec(document.getElementById('link').value);
+      m = re.exec(link);
       if (m === null)
       {
         window.alert('Hibás link formátum!');
@@ -49,16 +56,39 @@
       document.getElementById('title').value = decodeURI(m[1]);
       document.getElementById('geo').value = `${m[2]}, ${m[3]}`;
       document.getElementById('desc').value = decodeURI(m[4] ?? "");
+      with (document.getElementById('link'))
+        innerText = href = webRoot + m[0];
     }
+    function init()
+    {
+      if (location.hash)
+      {
+        parseLink(location.hash);
+        document.getElementById('linkEdit').value = location.hash;
+      }
+    }
+    window.addEventListener('popstate', () => {
+      if (!location.hash)
+      {
+        document.getElementById('title').value = '';
+        document.getElementById('geo').value = '';
+        document.getElementById('desc').value = '';
+        document.getElementById('link').innerText = '';
+      }
+      else
+        parseLink(location.hash);
+      document.getElementById('linkEdit').value = location.hash;
+    });
   </script>
 </head>
-<body>
+<body onload="init()">
   <h1>Helyjelölő link készítése</h1>
     <p><label for="title">Cím (csak sima szöveg):</label><br/><input type="text" id="title" maxLength="50" size="40"></p>
     <p><label for="geo">Geokoordináta (mint a Google koordináta):</label><br/><input type="text" id="geo" maxLength="40" size="40"></p>
     <p><label for="desc">Leírás (<a href="https://github.com/showdownjs/showdown/wiki/Showdown's-Markdown-syntax" tabindex="-1">Markdown szintaxis</a>):</label><br/><textarea id="desc" rows="20" style="width:100%"></textarea></p>
     <p><input type="submit" value="Link Készítése" onclick="return makeLink()"> <input type="submit" value="Link Visszafejtése" onclick="return parseLink()"></p>
-    <p><label for="result">Link:</label><input type="text" id="link" style="width: 100%" onfocus="this.select();"></p>
+    <p><label for="result">Link:</label><input type="text" id="linkEdit" style="width: 100%" onfocus="this.select();"></p>
+    <p><a id="link" target="_blank"></a></p>
   </div>
 </body>
 </html>


### PR DESCRIPTION
The generated links are now displayed as a clickable link at the bottom of the page.

Note for reviewer: https://kmlviewer.nsspot.net/ can be used to open KML files online.
