### PR TITLE
Updated the Lepence date

### DIFF
--- a/data.json
+++ b/data.json
@@ -43,7 +43,7 @@
 						"md":"data/Lepence.md",
 						"kml":"data/Lepence.kml",
 						"rat":7,
-						"upd":"2022 július"
+						"upd":"2022 október"
 					},
 					{
 						"ttl":"Dobogókő",


### PR DESCRIPTION
The route status and description is still the same.

Notes for reviewer:
* https://kmlviewer.nsspot.net/ can be used to open KML files online.
* https://sp3eder.github.io/huroutes/linkmaker.html can be used to decode location marker URLs.
