### PR TITLE
Added a workaround to make Google Translate work on the site

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="hu">
 <head>
   <meta charset="utf-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/res/huroutes.js
+++ b/res/huroutes.js
@@ -183,8 +183,14 @@ $(document).ready(function() {
 
     // Asynchronously loads the huroutes database
     $.getJSON('data.json', initializeContent)
-        .fail(function() {
-            console.error('Failed loading the route database.');
+        .fail(() => {
+            err = () => console.error('Failed loading the route database.');
+            // Google Translate workaround for correcting database path
+            gtBase = $('head base[href]')
+            if (0 < gtBase.length)
+                $.getJSON(gtBase.attr('href') + 'data.json', initializeContent).fail(err);
+            else
+                err();
         });
 
     // Initializing misc. huroutes app components


### PR DESCRIPTION
Notes for reviewer:
* https://kmlviewer.nsspot.net/ can be used to open KML files online.
* https://sp3eder.github.io/huroutes/linkmaker.html can be used to decode location marker URLs.
