### PR TITLE
Moved more localization-related code to the html file

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,6 +63,21 @@
     // huroutes requires that the language dictionary is provided here
     // The huroutes.lang.<html[lang]> attribute field must be filled in
     huroutes.lang.hu = {
+      'map': {
+        'Map': 'Térkép',
+        'Terrain': 'Domborzat',
+        'Satellite': 'Műhold',
+        'Google Map': 'Google Térkép',
+        'Google Terrain': 'Google Domborzat',
+        'Google Satellite': 'Google Műhold',
+        'Elevation Shading': 'Domborzat Kiemelés'
+      },
+      'themes': {
+        'System Theme': 'Rendszer megjelenése',
+        'Bright': 'Világos',
+        'Dark': 'Sötét',
+        'Dark with bright map': 'Sötét, világos térképpel'
+      },
       'updateDate': 'Az útvonal legutóbbi felderítésének ideje.',
       'rating': 'Az útvonal értékelése vezethetőség, változatosság, izgalom szempontjaiból.',
       'navToPoi': ' Navigáció <span class="nav-start">ehhez a helyhez</span>.',
@@ -78,7 +93,22 @@
       'zoomInTooltip': 'Térkép nagyítása',
       'zoomOutTooltip': 'Térkép kicsinyítése',
     }
+    // Hungarian map types
+    huroutes.opt.map.overlays['Turistautak'] = L.tileLayer('https://{s}.tile.openstreetmap.hu/tt/{z}/{x}/{y}.png', {attribution:'&copy; turistautak.hu',minZoom:5,maxZoom: 18,zIndex:100,className: 'overlay-turistautak'});
+    huroutes.opt.map.tileOverlays['Satellite'] = L.tileLayer('https://map.turistautak.hu/tiles/lines/{z}/{x}/{y}.png', {attribution:'&copy; turistautak.hu',minZoom:5,maxZoom: 18,zIndex:10,className: 'overlay-satelliteroads'});
   </script>
+  <style>
+    /* Dark mode for Turistautak map overlay */
+    .maps-dark .overlay-turistautak {
+      filter: brightness(0.8);
+      -webkit-filter: brightness(0.8);
+    }
+    /* Makes the satellite view's roads translucent */
+    .overlay-satelliteroads {
+      filter: opacity(0.6);
+      -webkit-filter: opacity(0.6);
+    }
+  </style>
 </head>
 
 <body>

--- a/res/huroutes.css
+++ b/res/huroutes.css
@@ -437,12 +437,6 @@ ul a.dropdown-toggle:hover {
  * Map view / map themes
  */
 
-/* Makes the sattelite view's roads translucent */
-.overlay-satteliteroads {
-  filter: opacity(0.6);
-  -webkit-filter: opacity(0.6);
-}
-
 /* A dark filter set for "normal" map styles */
 .maps-dark .tile-openstreetmap, .maps-dark .tile-googlemap, .maps-dark .tile-googleterrain {
   filter: brightness(0.6) invert(1) contrast(3) hue-rotate(200deg) saturate(0.3) brightness(0.7);
@@ -453,8 +447,8 @@ ul a.dropdown-toggle:hover {
   filter: brightness(0.65) invert(0.8) contrast(2.5) hue-rotate(200deg) saturate(0.6) brightness(0.8);
   -webkit-filter: brightness(0.65) invert(0.8) contrast(2.5) hue-rotate(200deg) saturate(0.6) brightness(0.8);
 }
-/* A slight darkening for sattelite maps in dark mode */
-.maps-dark .tile-sattelite, .maps-dark .tile-googlesattelite, .maps-dark .overlay-turistautak {
+/* A slight darkening for satellite maps in dark mode */
+.maps-dark .tile-satellite, .maps-dark .tile-googlesatellite {
   filter: brightness(0.8);
   -webkit-filter: brightness(0.8);
 }


### PR DESCRIPTION
This makes it easier to reuse huroutes.js for sites in a different language.

Notes for reviewer:
* https://kmlviewer.nsspot.net/ can be used to open KML files online.
* https://sp3eder.github.io/huroutes/linkmaker.html can be used to decode location marker URLs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Sp3EdeR/huroutes/165)
<!-- Reviewable:end -->
