### PR TITLE
Fixed Google Translate error with https://sp3eder.github.io/huroutes/index.html

### DIFF
--- a/res/huroutes.js
+++ b/res/huroutes.js
@@ -628,7 +628,7 @@ function getGoogleTranslateBase()
 {
     url = $('head base[href]').attr('href');
     if (url)
-        url = url.split('?')[0];
+        url = url.split('?')[0].replace(/[^/]+\.[^\s\./]{3,5}$/, '');
     return url;
 }
 


### PR DESCRIPTION

Notes for reviewer:
* https://kmlviewer.nsspot.net/ can be used to open KML files online.
* https://sp3eder.github.io/huroutes/linkmaker.html can be used to decode location marker URLs.
