### PR TITLE
Disabled link-cursor for curves

### DIFF
--- a/res/huroutes.js
+++ b/res/huroutes.js
@@ -327,6 +327,7 @@ function initLazyOverlay(id, lg)
             const styleMap = r2[0];
             lg.addLayer(L.geoJson(r1[0], {
                 attribution: cfg.attribution,
+                interactive: false,
                 style: (feature) =>
                     feature.properties.styleUrl && styleMap[feature.properties.styleUrl]
             }));


### PR DESCRIPTION
Notes for reviewer:
* https://kmlviewer.nsspot.net/ can be used to open KML files online.
* https://sp3eder.github.io/huroutes/linkmaker.html can be used to decode location marker URLs.
