### PR TITLE
Fixed randomly not loading data.json-embedded KMLs

### DIFF
--- a/res/huroutes.js
+++ b/res/huroutes.js
@@ -602,10 +602,7 @@ function addRoute(data)
         omnivore.kml(data.kml, null, layer).addTo(map);
     else
         // The 0-timeout runs the function asynchronously
-        tmout = setTimeout(() => {
-            omnivore.kml.parse(data.kml, null, layer).addTo(map);
-            clearTimeout(tmout);
-        }, 0);
+        setTimeout(() => omnivore.kml.parse(data.kml, null, layer).addTo(map));
     return routeId;
 }
 


### PR DESCRIPTION
Changed the asychronicity code for loading KMLs embedded into data.json to avoid race conditions that did not let the KML to load on screen.

Notes for reviewer:
* https://kmlviewer.nsspot.net/ can be used to open KML files online.
* https://sp3eder.github.io/huroutes/linkmaker.html can be used to decode location marker URLs.
