### PR TITLE
Better avoidance of a force-dark function

### DIFF
--- a/res/huroutes.css
+++ b/res/huroutes.css
@@ -2,6 +2,9 @@
  * Page generics
  */
 
+:root {
+  color-scheme: light dark;
+}
 body {
   font-size: 14px;
   overflow-x: hidden;


### PR DESCRIPTION
Many browsers have a forced dark mode feature for websites that only support light mode The force dark mode function should be disabled for this website, as it supports mode switching. This feature helps browsers detect that the website supports dark-mode and disable force dark.

Notes for reviewer:
* https://kmlviewer.nsspot.net/ can be used to open KML files online.
* https://sp3eder.github.io/huroutes/linkmaker.html can be used to decode location marker URLs.
