### PR TITLE
Fixed an incorrect date format

### DIFF
--- a/data.json
+++ b/data.json
@@ -90,7 +90,7 @@
 						"md":"data/Hereg.md",
 						"kml":"data/Hereg.kml",
 						"rat":7,
-						"upd":"2025 Április"
+						"upd":"2025 április"
 					},
 					{
 						"ttl":"Tarján - Agostyán",


### PR DESCRIPTION
Notes for reviewer:
* https://kmlviewer.nsspot.net/ can be used to open KML files online.
* https://sp3eder.github.io/huroutes/linkmaker.html can be used to decode location marker URLs.
