### PR TITLE
Update index.html w/new integrity hash

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,7 +66,7 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.bundle.min.js" integrity="sha256-GRJrh0oydT1CwS36bBeJK/2TggpaUQC6GzTaTQdZm0k=" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script src="https://cdn.jsdelivr.net/npm/showdown@2.1.0/dist/showdown.min.js" integrity="sha256-iOtvu+DCcN3zOEruDJYg0HDgkKJuB8Z0Ia42yQO11kk=" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-  <script src="https://cdn.jsdelivr.net/npm/leaflet-providers@2.0.0/leaflet-providers.min.js" integrity="sha256-MoLxVCCJOBvyaZFUhQu9NK/gdYqtyuZgKwjAajrC5wc=" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="https://cdn.jsdelivr.net/npm/leaflet-providers@2.0.0/leaflet-providers.min.js" integrity="sha256-ifjTwca542eE0PimNIlrxVCXTaTbWgm22oFBpgV69xs=" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script src="https://cdn.jsdelivr.net/npm/leaflet-omnivore@0.3.4/leaflet-omnivore.min.js" integrity="sha256-k1l+ouvMXT+0iRA8pc8e0dge4ZeGjXG6imrvWboFTRE=" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script src="https://cdn.jsdelivr.net/npm/leaflet.locatecontrol@0.79.0/dist/L.Control.Locate.min.js" integrity="sha256-jVdNHjjOOJMoykxLOdGxOUzGJDlmr8MM6sFF++b1/sI=" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script src="https://cdn.jsdelivr.net/npm/leaflet-touch-helper@2.0.0/leaflet-touch-helper.js" integrity="sha256-D7f8Sx6FbMkCBja376fGTwyyIwLt52KNUmbrTVbjQTk=" crossorigin="anonymous" referrerpolicy="no-referrer"></script>


### PR DESCRIPTION
Changed integrity hash on 3rd party dependency

Original error message:

```huroutes/:1 Failed to find a valid digest in the 'integrity' attribute for resource 'https://cdn.jsdelivr.net/npm/leaflet-providers@2.0.0/leaflet-providers.min.js' with computed SHA-256 integrity 'ifjTwca542eE0PimNIlrxVCXTaTbWgm22oFBpgV69xs='. The resource has been blocked.```