### PR TITLE
Fixed menu tick/text clipping

### DIFF
--- a/res/huroutes.css
+++ b/res/huroutes.css
@@ -256,6 +256,8 @@ ul a.dropdown-toggle {
   font-size: 1.1em;
   overflow: hidden;
   padding: 10px;
+  padding-right: 25px;
+  text-overflow: ellipsis;
 }
 ul ul a.dropdown-toggle {
   padding-left: 20px !important;


### PR DESCRIPTION
At particular menu widths, menu text and expansion tick could clip with one another. Increased the text's right padding and overflow handling to avoid this.

Notes for reviewer:
* https://kmlviewer.nsspot.net/ can be used to open KML files online.
* https://sp3eder.github.io/huroutes/linkmaker.html can be used to decode location marker URLs.
