### PR TITLE
Added route labels and unified page font

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,6 +56,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@forevolve/bootstrap-dark@4.0.0/dist/css/toggle-bootstrap.min.css" integrity="sha256-FrYhUW1FIy6GrbYaAdOOeWzysJaYHvXRTvC5JkpI2Io=" crossorigin="anonymous" referrerpolicy="no-referrer">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@forevolve/bootstrap-dark@4.0.0/dist/css/toggle-bootstrap-dark.min.css" integrity="sha256-wppe1Gjdh2nq3OuT3UjPkGYSslQEWHzCxd1CrPEAjUM=" crossorigin="anonymous" referrerpolicy="no-referrer">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5.15.4/css/all.min.css" integrity="sha256-mUZM63G8m73Mcidfrv5E+Y61y7a12O5mW4ezU3bxqW4=" crossorigin="anonymous" referrerpolicy="no-referrer">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/noto-sans@5.2.10/index.css" integrity="sha256-DgDXFQXB8ZVeD/0eW8nW7FEA5BmUwx/vn6XTUR4z7to=" crossorigin="anonymous" referrerpolicy="no-referrer">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flag-icons@7.2.0/css/flag-icons.min.css" integrity="sha256-6aS/gsIUwE4ARg66wCWWoqDScD/npQknxfa/E0+fdHQ=" crossorigin="anonymous" referrerpolicy="no-referrer">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="anonymous" referrerpolicy="no-referrer">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet.locatecontrol@0.79.0/dist/L.Control.Locate.min.css" integrity="sha256-b1FUshftUDgzY/VtFMamPDs0o3GER52S9Tk8IK+wOoE=" crossorigin="anonymous" referrerpolicy="no-referrer">
@@ -70,6 +71,7 @@
   <script src="https://cdn.jsdelivr.net/npm/leaflet-omnivore@0.3.4/leaflet-omnivore.min.js" integrity="sha256-k1l+ouvMXT+0iRA8pc8e0dge4ZeGjXG6imrvWboFTRE=" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script src="https://cdn.jsdelivr.net/npm/leaflet.locatecontrol@0.79.0/dist/L.Control.Locate.min.js" integrity="sha256-jVdNHjjOOJMoykxLOdGxOUzGJDlmr8MM6sFF++b1/sI=" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script src="https://cdn.jsdelivr.net/npm/leaflet-touch-helper@2.0.0/leaflet-touch-helper.js" integrity="sha256-D7f8Sx6FbMkCBja376fGTwyyIwLt52KNUmbrTVbjQTk=" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="https://cdn.jsdelivr.net/npm/leaflet-textpath@1.3.0/leaflet.textpath.js" integrity="sha256-+y9A4dNxtUwcT8kcotZMxItR5aEhpH0kbB5UneQ1Pao=" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 
   <!-- huroutes codebase and style -->
   <link rel="stylesheet" href="res/huroutes.css" />

--- a/res/huroutes.css
+++ b/res/huroutes.css
@@ -6,6 +6,7 @@
   color-scheme: light dark;
 }
 body {
+  font-family: "Noto Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Liberation Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji" !important;
   font-size: 14px;
   overflow-x: hidden;
   padding: 0;


### PR DESCRIPTION
* route labels now show directional labels with the route name
* the labels use a mixed noto-sans and font-awesome fonts, both web fonts
* the main page font has been updated to use the noto-sans web font primarily

Notes for reviewer:
* https://kmlviewer.nsspot.net/ can be used to open KML files online.
* https://sp3eder.github.io/huroutes/linkmaker.html can be used to decode location marker URLs.

---

This pull request introduces support for displaying styled route labels directly on the map, along with improvements to font consistency across the application. The main changes involve adding a new font, configuring route label appearance and behavior, and updating the map logic to show or hide these labels based on zoom level.

**Map Route Label Feature:**

* Added configuration for route labels in `huroutes.opt.routeLabels`, including minimum zoom level, label text template, and styling attributes. (`res/huroutes.js` [res/huroutes.jsR157-R175](diffhunk://#diff-3cc3a281ac55c85ae08487262eac1cad2c6df3fb5977acb6642cb98492f52b0fR157-R175))
* Implemented `initRouteLabels` and `updateRouteLabels` functions to manage label visibility based on map zoom, and to render labels using the configured style and template. (`res/huroutes.js` [[1]](diffhunk://#diff-3cc3a281ac55c85ae08487262eac1cad2c6df3fb5977acb6642cb98492f52b0fR863-R905) [[2]](diffhunk://#diff-3cc3a281ac55c85ae08487262eac1cad2c6df3fb5977acb6642cb98492f52b0fR289)
* Modified the `addRoute` function to associate each map layer with its route name, enabling label display. (`res/huroutes.js` [res/huroutes.jsR622](diffhunk://#diff-3cc3a281ac55c85ae08487262eac1cad2c6df3fb5977acb6642cb98492f52b0fR622))
* Added the `leaflet-textpath` library to enable text rendering along map paths. (`index.html` [index.htmlR74](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R74))

**Font and Style Enhancements:**

* Added the "Noto Sans" font via CDN and set it as the primary font for the application, ensuring consistent appearance and compatibility with route labels. (`index.html` [[1]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R59) `res/huroutes.css` [[2]](diffhunk://#diff-c780b1862b3c99f599c45d941c9a889a7fe03b412376a9193740bb4fada4c8afR9)