### PR TITLE
Reduced visual clutter

### DIFF
--- a/res/huroutes.js
+++ b/res/huroutes.js
@@ -159,7 +159,7 @@ const huroutes = {
             'minZoom': 11, // The minimum zoom level at which route labels are shown
             // The text template used for route labels. {0} is replaced with the route title.
             // \uf105 is this: https://fontawesome.com/v5/icons/angle-right?f=classic&s=solid.
-            'textTemplate': "\uf105\uf105\uf105\uf105\uf105\uf105   {0}   \uf105\uf105\uf105\uf105\uf105\uf105",
+            'textTemplate': "      \uf105\uf105\uf105   {0}   \uf105\uf105\uf105      ",
             'attributes': {
                 'fill': '#ccc',
                 'font-family': '"Noto Sans", "Font Awesome 5 Free", Roboto, sans-serif',
@@ -1319,3 +1319,4 @@ if (!localStorage.shownPwaAd)
 }
 
 })(); // End of PWA code
+


### PR DESCRIPTION
This pull request makes a minor adjustment to the route label appearance in `res/huroutes.js`. The main change is a simplification of the `textTemplate` used for route labels, reducing the number of angle-right icons displayed around the route title.

- Simplified the `textTemplate` for route labels by reducing the number of `\uf105` (angle-right) icons before and after the route title in the `huroutes` configuration.