### PR TITLE
Added the full send map as a layer

### DIFF
--- a/.github/actions/build-website/action.yml
+++ b/.github/actions/build-website/action.yml
@@ -19,3 +19,8 @@ runs:
       shell: bash
       run: |
           "$HUROUTES_BUILD_PYTHON" ".github/scripts/get-curve-map.py" "https://kml.roadcurvature.com/europe/hungary.c_1000.kmz" "map/curves.geo.json" "map/curves-style.json"
+    - name: Download full send data
+      # This step downloads the full send map's data for a map overlay.
+      shell: bash
+      run: |
+          "$HUROUTES_BUILD_PYTHON" ".github/scripts/get-full-send-map.py" "hungary" "map/full-send.geo.json"

--- a/.github/scripts/get-full-send-map.py
+++ b/.github/scripts/get-full-send-map.py
@@ -1,0 +1,55 @@
+import argparse
+import json
+import os
+import re
+import urllib.request as req
+
+
+MAP_ID = 1381865
+UMAP_METADATA_URL = "https://umap.openstreetmap.fr/en/map/%s/geojson/" % MAP_ID
+UMAP_DATALAYER_URL_TEMPLATE = "https://umap.openstreetmap.fr/en/datalayer/%s/%s/" % (MAP_ID, '%s')
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('datalayer_filter', help='A regex filter of the name of the datalayer.')
+    parser.add_argument('geojson_path', help='The path of the created geojson file.')
+    args = parser.parse_args()
+
+    url = UMAP_METADATA_URL
+    print("Downloading %s file..." % url)
+    mapData = req.urlopen(req.Request(url), timeout=30).read()
+
+    print("Parsing the map metadata...")
+    mapData = json.loads(mapData)
+    layer_ids = [
+        layer['id'] for layer in mapData['properties']['datalayers']
+        if re.match(args.datalayer_filter, layer['properties']['name'])
+    ]
+    if not layer_ids or len(layer_ids) > 1:
+        raise ValueError("Expected exactly one datalayer to match the filter, but found %d." % len(layer_ids))
+
+    url = UMAP_DATALAYER_URL_TEMPLATE % layer_ids[0]
+    print("Downloading the datalayer from %s..." % url)
+    datalayerData = req.urlopen(req.Request(url), timeout=30).read()
+    geofeats = json.loads(datalayerData)['features']
+
+    print("Removing GeoJSON feature descriptions...")
+    for props in (f['properties'] for f in geofeats):
+        if 'description' in props:
+            del props['description']
+
+    print("Ensuring that the output directory exists...")
+    outDir = os.path.dirname(args.geojson_path)
+    if outDir:
+        os.makedirs(outDir, exist_ok=True)
+
+    print("Writing GeoJSON data to %s..." % args.geojson_path)
+    with open(args.geojson_path, 'w') as f:
+        json.dump({
+            'type': 'FeatureCollection',
+            'features': list(geofeats)
+        }, f, separators=(',', ':'))
+
+if __name__ == "__main__":
+    main()

--- a/res/huroutes.js
+++ b/res/huroutes.js
@@ -28,7 +28,8 @@ const huroutes = {
             // Choosable overlay sources supported in the layer selector. All are off by default.
             'overlays': {
                 'Elevation Shading': L.tileLayer('https://map.turistautak.hu/tiles/shading/{z}/{x}/{y}.png', {attribution:'&copy; turistautak.hu',minZoom:5,maxZoom: 18,zIndex:5,className: 'overlay-dem'}),
-                'Curvature': L.layerGroup()
+                'Curvature': L.layerGroup(),
+                'Full Send': L.layerGroup()
             },
             // Overlay sources that are always shown and hidden along with specific map tile sources.
             // The name of the overlay must be the same as the tile layer to which it is bound.
@@ -41,6 +42,11 @@ const huroutes = {
                 'geojson': 'map/curves.geo.json',
                 'style': 'map/curves-style.json',
                 'attribution': 'Curves: &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+            },
+            // Full Send data definition, used to populate the Full Send overlay when first viewed.
+            'fullSendData': {
+                'geojson': 'map/full-send.geo.json',
+                'attribution': 'Full Send Map: &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
             }
         },
         // A list of navigation service providers that can be chosen for the "navigate to" links'.
@@ -474,6 +480,18 @@ function initLazyOverlay(id, lg)
                 interactive: false,
                 style: (feature) =>
                     feature.properties.styleUrl && styleMap[feature.properties.styleUrl]
+            }));
+        });
+    }
+
+    // Initialize the Full Send lazy overlay's contents.
+    if (id == 'Full Send')
+    {
+        const cfg = huroutes.opt.map.fullSendData;
+        getJSON(cfg.geojson).done(r1 => {
+            lg.addLayer(L.geoJson(r1[0], {
+                attribution: cfg.attribution,
+                interactive: false
             }));
         });
     }


### PR DESCRIPTION
Notes for reviewer:
* https://kmlviewer.nsspot.net/ can be used to open KML files online.
* https://sp3eder.github.io/huroutes/linkmaker.html can be used to decode location marker URLs.
